### PR TITLE
Moved Publisher,made eventProducer Optional & Removed Type Casting.

### DIFF
--- a/channel-handler-http/src/main/java/com/flipkart/phantom/runtime/impl/server/netty/handler/http/RoutingHttpChannelHandler.java
+++ b/channel-handler-http/src/main/java/com/flipkart/phantom/runtime/impl/server/netty/handler/http/RoutingHttpChannelHandler.java
@@ -18,7 +18,6 @@ package com.flipkart.phantom.runtime.impl.server.netty.handler.http;
 
 import com.flipkart.phantom.event.ServiceProxyEventProducer;
 import com.flipkart.phantom.http.impl.HttpProxy;
-import com.flipkart.phantom.http.impl.HttpProxyExecutor;
 import com.flipkart.phantom.http.impl.HttpRequestWrapper;
 import com.flipkart.phantom.task.spi.Executor;
 import com.flipkart.phantom.task.spi.repository.ExecutorRepository;
@@ -136,8 +135,11 @@ public abstract class RoutingHttpChannelHandler extends SimpleChannelUpstreamHan
         } finally {
 
 	        // Publishes event both in case of success and failure.
-	        Class eventSource = (executor == null) ? this.getClass() :((HttpProxyExecutor)executor).getProxy().getClass();
-	        eventProducer.publishEvent(executor, request.getUri(), eventSource, HTTP_HANDLER);
+	        Class eventSource = (executor == null) ? this.getClass() : executor.getClass();
+            if (eventProducer !=null)
+                eventProducer.publishEvent(executor, request.getUri(), eventSource, HTTP_HANDLER);
+            else
+                LOGGER.debug("eventProducer not set, not publishing event");
         }
 
         // send response

--- a/channel-handler-thrift/src/main/java/com/flipkart/phantom/runtime/impl/server/netty/handler/thrift/ThriftChannelHandler.java
+++ b/channel-handler-thrift/src/main/java/com/flipkart/phantom/runtime/impl/server/netty/handler/thrift/ThriftChannelHandler.java
@@ -64,7 +64,7 @@ public class ThriftChannelHandler extends SimpleChannelUpstreamHandler {
 
     /** Event Type for publishing all events which are generated here */
     private final static String THRIFT_HANDLER = "THRIFT_HANDLER";
-	
+
     /**
      * Overriden superclass method. Adds the newly created Channel to the default channel group and calls the super class {@link #channelOpen(ChannelHandlerContext, ChannelStateEvent)} method
      * @see org.jboss.netty.channel.SimpleChannelUpstreamHandler#channelOpen(org.jboss.netty.channel.ChannelHandlerContext, org.jboss.netty.channel.ChannelStateEvent)
@@ -104,9 +104,12 @@ public class ThriftChannelHandler extends SimpleChannelUpstreamHandler {
                 throw new RuntimeException("Error in executing Thrift request: " + thriftProxy + ":" + message.name, e);
             } finally {
 	            // Publishes event both in case of success and failure.
-	            Class eventSource = (executor == null) ? this.getClass() : Class.forName(((ThriftProxyExecutor)executor).getThriftProxy().getThriftServiceClass());
+	            Class eventSource = (executor == null) ? this.getClass() : executor.getClass();
 	            String commandName = thriftProxy + ":" + message.name;
-	            eventProducer.publishEvent(executor, commandName, eventSource, THRIFT_HANDLER);
+                if (eventProducer !=null)
+                    eventProducer.publishEvent(executor, commandName, eventSource, THRIFT_HANDLER);
+                else
+                    LOGGER.debug("eventProducer not set, not publishing event");
             }
             // write the result to the output channel buffer
 			Channels.write(ctx, event.getFuture(), ((ThriftNettyChannelBuffer)clientTransport).getOutputBuffer());

--- a/runtime-oio-uds/src/main/java/com/flipkart/phantom/runtime/impl/server/oio/UDSOIOServer.java
+++ b/runtime-oio-uds/src/main/java/com/flipkart/phantom/runtime/impl/server/oio/UDSOIOServer.java
@@ -248,9 +248,13 @@ public class UDSOIOServer extends AbstractNetworkServer {
                 throw new RuntimeException("Error in processing command : " + e.getMessage(), e);
             } finally {
                 // Publishes event both in case of success and failure.
-                Class eventSource = (executor == null) ? this.getClass() : executor.getTaskHandler().getClass();
+                Class eventSource = (executor == null) ? this.getClass() : executor.getClass();
                 String commandName = (readCommand == null) ? null : readCommand.getCommand();
-                eventProducer.publishEvent(executor, commandName, eventSource, COMMAND_HANDLER);
+                if (eventProducer !=null)
+                    eventProducer.publishEvent(executor, commandName, eventSource, COMMAND_HANDLER);
+                else
+                    LOGGER.debug("eventProducer not set, not publishing event");
+
                 if (client !=null) {
                     try {
                         client.close();

--- a/runtime/src/main/java/com/flipkart/phantom/runtime/impl/server/netty/handler/command/AsyncCommandProcessingChannelHandler.java
+++ b/runtime/src/main/java/com/flipkart/phantom/runtime/impl/server/netty/handler/command/AsyncCommandProcessingChannelHandler.java
@@ -60,7 +60,7 @@ public class AsyncCommandProcessingChannelHandler extends SimpleChannelUpstreamH
 		this.defaultChannelGroup.add(event.getChannel());
 	}
 
-	/**
+    /**
 	 * Interface method implementation. Reads and processes commands sent to the service proxy. Expects data in the command protocol defined in the class summary.
 	 * Discards commands that do not have a {@link com.flipkart.phantom.task.impl.TaskHandler} mapping.
 	 * @see org.jboss.netty.channel.SimpleChannelUpstreamHandler#handleUpstream(org.jboss.netty.channel.ChannelHandlerContext, org.jboss.netty.channel.ChannelEvent)
@@ -94,9 +94,12 @@ public class AsyncCommandProcessingChannelHandler extends SimpleChannelUpstreamH
             }
             finally {
                 // Publishes event both in case of success and failure.
-                Class eventSource = (executor == null) ? this.getClass() : executor.getTaskHandler().getClass();
+                Class eventSource = (executor == null) ? this.getClass() : executor.getClass();
                 commandName = (readCommand == null) ? null : readCommand.getCommand();
-                eventProducer.publishEvent(executor, commandName, eventSource, ASYNC_COMMAND_HANDLER);
+                if (eventProducer !=null)
+                    eventProducer.publishEvent(executor, commandName, eventSource, ASYNC_COMMAND_HANDLER);
+                else
+                    LOGGER.debug("eventProducer not set, not publishing event");
             }
         }
 		super.handleUpstream(ctx, event);

--- a/runtime/src/main/java/com/flipkart/phantom/runtime/impl/server/netty/handler/command/CommandProcessingChannelHandler.java
+++ b/runtime/src/main/java/com/flipkart/phantom/runtime/impl/server/netty/handler/command/CommandProcessingChannelHandler.java
@@ -63,7 +63,7 @@ public class CommandProcessingChannelHandler extends SimpleChannelUpstreamHandle
 		this.defaultChannelGroup.add(event.getChannel());
 	}
 
-	/**
+    /**
 	 * Interface method implementation. Reads and processes commands sent to the service proxy. Expects data in the command protocol defined in the class summary.
 	 * Discards commands that do not have a {@link TaskHandler} mapping. 
 	 * @see org.jboss.netty.channel.SimpleChannelUpstreamHandler#handleUpstream(org.jboss.netty.channel.ChannelHandlerContext, org.jboss.netty.channel.ChannelEvent)
@@ -103,10 +103,12 @@ public class CommandProcessingChannelHandler extends SimpleChannelUpstreamHandle
 			}
             finally {
                 // Publishes event both in case of success and failure.
-                Class eventSource = (executor == null) ? this.getClass() : executor.getTaskHandler().getClass();
+                Class eventSource = (executor == null) ? this.getClass() : executor.getClass();
                 String commandName = (readCommand == null) ? null : readCommand.getCommand();
-                eventProducer.publishEvent(executor, commandName, eventSource, COMMAND_HANDLER);
-
+                if (eventProducer !=null)
+                    eventProducer.publishEvent(executor, commandName, eventSource, COMMAND_HANDLER);
+                else
+                    LOGGER.debug("eventProducer not set, not publishing event");
             }
         }
 		super.handleUpstream(ctx, event);

--- a/runtime/src/main/resources/packaged/common-proxy-config.xml
+++ b/runtime/src/main/resources/packaged/common-proxy-config.xml
@@ -10,17 +10,6 @@
 	<!-- This event producer bean is declared primarily for publishing Bootstrap lifecycle events -->
 	<bean id="platformEventProducer" class="org.trpr.platform.core.impl.event.PlatformEventProducerImpl"/>
 
-    <!--This event producer bean is declared primarily for using in ServiceProxyEvent Producer-->
-    <bean id="endpointEventProducer" class="org.trpr.platform.core.impl.event.EndpointEventProducerImpl">
-        <property name="defaultEndpointURI" value="evt://com.flipkart.phantom.events.ALL"/>
-    </bean>
-
-    <!--This event producer bean is declared primarily for publishing Service Proxy Events-->
-    <bean id="serviceProxyEventProducer" class="com.flipkart.phantom.event.ServiceProxyEventProducer">
-        <!--Current implementation publishes events to endpoints based on Handlers. Nothing is published to ALL-->
-        <property name="eventProducer" ref="endpointEventProducer"/>
-    </bean>
-
     <!--Three types of subscriptions are supported based on Protocol used by handler.-->
     <bean id="applicationEventMulticaster" class="org.trpr.platform.core.impl.event.PlatformEventMulticaster">
         <property name="subscriptions">

--- a/sample-http-proxy/src/main/resources/external/spring-proxy-listener-config.xml
+++ b/sample-http-proxy/src/main/resources/external/spring-proxy-listener-config.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="
     http://www.springframework.org/schema/beans classpath:org/springframework/beans/factory/xml/spring-beans-2.5.xsd
     http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-2.0.xsd
@@ -53,5 +52,32 @@
 
     <!-- the registry of HttpProxies -->
     <bean id="httpProxyRegistry" class="com.flipkart.phantom.http.impl.registry.HttpProxyRegistry" />
+
+    <!-- Task Handler Event Publishers & Consumers-->
+
+    <!--This event producer bean is declared primarily for using in ServiceProxyEvent Producer-->
+    <bean id="endpointEventProducer" class="org.trpr.platform.core.impl.event.EndpointEventProducerImpl">
+        <property name="defaultEndpointURI" value="evt://com.flipkart.phantom.events.ALL"/>
+    </bean>
+
+    <!--This event producer bean is declared primarily for publishing Service Proxy Events-->
+    <bean id="serviceProxyEventProducer" class="com.flipkart.phantom.event.ServiceProxyEventProducer">
+        <!--Current implementation publishes events to endpoints based on Handlers. Nothing is published to ALL-->
+        <property name="eventProducer" ref="endpointEventProducer"/>
+    </bean>
+
+    <!--This bean corresponds to consumer of Service Proxy Events which listens to all event types and logs errors-->
+    <bean id="errorRequestLogger" class="com.flipkart.phantom.event.consumer.RequestLogger">
+        <property name="subscriptions">
+            <list>
+                <value>evt://com.flipkart.phantom.events.TASK_HANDLER</value>
+                <value>evt://com.flipkart.phantom.events.THRIFT_HANDLER</value>
+                <value>evt://com.flipkart.phantom.events.HTTP_HANDLER</value>
+                <value>evt://com.flipkart.phantom.events.COMMAND_HANDLER</value>
+                <value>evt://com.flipkart.phantom.events.ASYNC_COMMAND_HANDLER</value>
+            </list>
+        </property>
+    </bean>
+    <!-- Task Handler Event Publishers & Consumers-->
 
 </beans>

--- a/sample-http-proxy/src/main/resources/external/spring-proxy-listener-config_Routing_Sample.xml
+++ b/sample-http-proxy/src/main/resources/external/spring-proxy-listener-config_Routing_Sample.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="
     http://www.springframework.org/schema/beans classpath:org/springframework/beans/factory/xml/spring-beans-2.5.xsd
     http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-2.0.xsd
@@ -59,5 +58,32 @@
 
     <!-- the registry of HttpProxies -->
     <bean id="httpProxyRegistry" class="com.flipkart.phantom.http.impl.registry.HttpProxyRegistry" />
+
+    <!-- Task Handler Event Publishers & Consumers-->
+
+    <!--This event producer bean is declared primarily for using in ServiceProxyEvent Producer-->
+    <bean id="endpointEventProducer" class="org.trpr.platform.core.impl.event.EndpointEventProducerImpl">
+        <property name="defaultEndpointURI" value="evt://com.flipkart.phantom.events.ALL"/>
+    </bean>
+
+    <!--This event producer bean is declared primarily for publishing Service Proxy Events-->
+    <bean id="serviceProxyEventProducer" class="com.flipkart.phantom.event.ServiceProxyEventProducer">
+        <!--Current implementation publishes events to endpoints based on Handlers. Nothing is published to ALL-->
+        <property name="eventProducer" ref="endpointEventProducer"/>
+    </bean>
+
+    <!--This bean corresponds to consumer of Service Proxy Events which listens to all event types and logs errors-->
+    <bean id="errorRequestLogger" class="com.flipkart.phantom.event.consumer.RequestLogger">
+        <property name="subscriptions">
+            <list>
+                <value>evt://com.flipkart.phantom.events.TASK_HANDLER</value>
+                <value>evt://com.flipkart.phantom.events.THRIFT_HANDLER</value>
+                <value>evt://com.flipkart.phantom.events.HTTP_HANDLER</value>
+                <value>evt://com.flipkart.phantom.events.COMMAND_HANDLER</value>
+                <value>evt://com.flipkart.phantom.events.ASYNC_COMMAND_HANDLER</value>
+            </list>
+        </property>
+    </bean>
+    <!-- Task Handler Event Publishers & Consumers-->
 
 </beans>

--- a/sample-thrift-proxy/src/main/resources/external/spring-proxy-listener-config.xml
+++ b/sample-thrift-proxy/src/main/resources/external/spring-proxy-listener-config.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="
     http://www.springframework.org/schema/beans classpath:org/springframework/beans/factory/xml/spring-beans-2.5.xsd
     http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-2.0.xsd
@@ -45,5 +44,32 @@
     </bean>
 
     <bean id="thriftProxyRegistry" class="com.flipkart.phantom.thrift.impl.registry.ThriftProxyRegistry"></bean>
+
+    <!-- Task Handler Event Publishers & Consumers-->
+
+    <!--This event producer bean is declared primarily for using in ServiceProxyEvent Producer-->
+    <bean id="endpointEventProducer" class="org.trpr.platform.core.impl.event.EndpointEventProducerImpl">
+        <property name="defaultEndpointURI" value="evt://com.flipkart.phantom.events.ALL"/>
+    </bean>
+
+    <!--This event producer bean is declared primarily for publishing Service Proxy Events-->
+    <bean id="serviceProxyEventProducer" class="com.flipkart.phantom.event.ServiceProxyEventProducer">
+        <!--Current implementation publishes events to endpoints based on Handlers. Nothing is published to ALL-->
+        <property name="eventProducer" ref="endpointEventProducer"/>
+    </bean>
+
+    <!--This bean corresponds to consumer of Service Proxy Events which listens to all event types and logs errors-->
+    <bean id="errorRequestLogger" class="com.flipkart.phantom.event.consumer.RequestLogger">
+        <property name="subscriptions">
+            <list>
+                <value>evt://com.flipkart.phantom.events.TASK_HANDLER</value>
+                <value>evt://com.flipkart.phantom.events.THRIFT_HANDLER</value>
+                <value>evt://com.flipkart.phantom.events.HTTP_HANDLER</value>
+                <value>evt://com.flipkart.phantom.events.COMMAND_HANDLER</value>
+                <value>evt://com.flipkart.phantom.events.ASYNC_COMMAND_HANDLER</value>
+            </list>
+        </property>
+    </bean>
+    <!-- Task Handler Event Publishers & Consumers-->
 
 </beans>

--- a/task-http/src/main/java/com/flipkart/phantom/http/impl/HttpProxyExecutor.java
+++ b/task-http/src/main/java/com/flipkart/phantom/http/impl/HttpProxyExecutor.java
@@ -88,10 +88,4 @@ public class HttpProxyExecutor extends HystrixCommand<HttpResponse> implements E
     protected HttpResponse getFallback() {
         return proxy.fallbackRequest(method,uri,data);
     }
-
-    /** Getter/Setter methods */
-    public HttpProxy getProxy() {
-        return proxy;
-    }
-    /** End Getter/Setter methods */
 }

--- a/task-thrift/src/main/java/com/flipkart/phantom/thrift/impl/ThriftProxyExecutor.java
+++ b/task-thrift/src/main/java/com/flipkart/phantom/thrift/impl/ThriftProxyExecutor.java
@@ -207,9 +207,6 @@ public class ThriftProxyExecutor extends HystrixCommand<TTransport> implements E
     public void setClientTransport(TTransport clientTransport) {
         this.clientTransport = clientTransport;
     }
-    public ThriftProxy getThriftProxy() {
-        return thriftProxy;
-    }
     /** End Getter/Setter methods */
 
 }

--- a/task/src/main/java/com/flipkart/phantom/task/impl/TaskContextImpl.java
+++ b/task/src/main/java/com/flipkart/phantom/task/impl/TaskContextImpl.java
@@ -21,6 +21,8 @@ import org.codehaus.jackson.map.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Future;
@@ -40,7 +42,7 @@ public class TaskContextImpl implements TaskContext {
     private static final String GET_CONFIG_COMMAND = "getConfig";
 
     /** Host name for this TaskContext */
-    private String hostName;
+    private static String hostName;
 
     /** ObjectMapper instance */
     private ObjectMapper objectMapper = new ObjectMapper();
@@ -48,6 +50,15 @@ public class TaskContextImpl implements TaskContext {
 
     /** The TaskHandlerExecutorRepository instance for getting thrift handler executor instances */
     private TaskHandlerExecutorRepository executorRepository;
+
+    static
+    {
+        try {
+            hostName = InetAddress.getLocalHost().getHostName();
+        } catch (UnknownHostException e) {
+            LOGGER.error("Unable to find host name", e);
+        }
+    }
 
     /**
      * Gets the config from the ConfigTaskHandler (@link{GET_CONFIG_COMMAND}).
@@ -122,6 +133,10 @@ public class TaskContextImpl implements TaskContext {
     }
     public void setObjectMapper(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
+    }
+    @Override
+    public String getHostName() {
+        return hostName;
     }
     /** End Getter/Setter methods */
 }

--- a/task/src/main/java/com/flipkart/phantom/task/impl/TaskHandlerExecutor.java
+++ b/task/src/main/java/com/flipkart/phantom/task/impl/TaskHandlerExecutor.java
@@ -168,9 +168,5 @@ public class TaskHandlerExecutor extends HystrixCommand<TaskResult> implements E
         }
         return this.taskHandler.getCallInvocationType();
     }
-
-    public TaskHandler getTaskHandler() {
-        return taskHandler;
-    }
     /** End Getter/Setter methods */
 }

--- a/task/src/main/java/com/flipkart/phantom/task/spi/TaskContext.java
+++ b/task/src/main/java/com/flipkart/phantom/task/spi/TaskContext.java
@@ -70,5 +70,7 @@ public interface TaskContext {
 
 	/** Gets the ObjectMapper instance for result serialization to JSON*/
 	public ObjectMapper getObjectMapper();
-	
+
+    /** Gets Host Name of current server */
+    String getHostName();
 }


### PR DESCRIPTION
Moved Publisher out of common-proxy-config to spring-proxy-configs so producer-consumer lie in same context.

Removed Type Casts to get Source Event.

Made eventProducer Optional, in case it is not declared event publishing will be skipped.
