### PR TITLE
Overriding "getCacheKey" in HystrixTaskHandler. This enables all task

### DIFF
--- a/channel-handler-http/src/main/java/com/flipkart/phantom/runtime/impl/server/netty/handler/http/RoutingHttpChannelHandler.java
+++ b/channel-handler-http/src/main/java/com/flipkart/phantom/runtime/impl/server/netty/handler/http/RoutingHttpChannelHandler.java
@@ -22,6 +22,7 @@ import com.flipkart.phantom.http.impl.HttpProxy;
 import com.flipkart.phantom.http.impl.HttpRequestWrapper;
 import com.flipkart.phantom.task.spi.Executor;
 import com.flipkart.phantom.task.spi.repository.ExecutorRepository;
+import com.netflix.hystrix.strategy.concurrency.HystrixRequestContext;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
@@ -144,6 +145,7 @@ public abstract class RoutingHttpChannelHandler extends SimpleChannelUpstreamHan
 
         // execute
         HttpResponse response = null;
+        HystrixRequestContext hystrixRequestContext = HystrixRequestContext.initializeContext();
         try {
             response = (HttpResponse) executor.execute();
         } catch (Exception e) {
@@ -161,6 +163,8 @@ public abstract class RoutingHttpChannelHandler extends SimpleChannelUpstreamHan
                 eventProducer.publishEvent(eventBuilder.build());
             } else
                 LOGGER.debug("eventProducer not set, not publishing event");
+
+            hystrixRequestContext.shutdown();
         }
 
         // send response

--- a/task-http/src/main/java/com/flipkart/phantom/http/impl/HttpProxyExecutor.java
+++ b/task-http/src/main/java/com/flipkart/phantom/http/impl/HttpProxyExecutor.java
@@ -88,6 +88,11 @@ public class HttpProxyExecutor extends HystrixCommand<HttpResponse> implements E
         return proxy.fallbackRequest(this.httpRequestWrapper);
     }
 
+    @Override
+    protected String getCacheKey() {
+        return this.httpRequestWrapper.getMethod()+this.httpRequestWrapper.getUri();
+    }
+
     public ServiceProxyEvent.Builder getEventBuilder() {
         return eventBuilder;
     }

--- a/task/src/main/java/com/flipkart/phantom/task/impl/HystrixTaskHandler.java
+++ b/task/src/main/java/com/flipkart/phantom/task/impl/HystrixTaskHandler.java
@@ -71,6 +71,20 @@ public abstract class HystrixTaskHandler extends TaskHandler {
      */
     public abstract TaskResult getFallBack(TaskContext taskContext, String command, Map<String,String> params, byte[] data);
 
+
+    /**
+     * This method returns a valid {@link com.netflix.hystrix.HystrixCommand} cache key
+     * that is used to cache futures of requests, thereby eliminating redundant requests
+     * in the context of a single {@link com.netflix.hystrix.strategy.concurrency.HystrixRequestContext}
+     * If it is not Overriden in the derived class, it returns null, which bypasses the request
+     * caching mechanism in hystrix
+     *
+     * @return String cache key
+     */
+    public String getCacheKey(){
+        return null;
+    }
+
     /**
      * Return the ExecutionIsolationStrategy. Thread is the default.
      */

--- a/task/src/main/java/com/flipkart/phantom/task/impl/TaskHandlerExecutor.java
+++ b/task/src/main/java/com/flipkart/phantom/task/impl/TaskHandlerExecutor.java
@@ -167,6 +167,24 @@ public class TaskHandlerExecutor extends HystrixCommand<TaskResult> implements E
     }
 
     /**
+     * This method returns a valid {@link com.netflix.hystrix.HystrixCommand} cache key
+     * from the underlying {@link HystrixTaskHandler} that is used to cache futures of requests,
+     * thereby eliminating redundant requests in the context of a single {@link com.netflix.hystrix.strategy.concurrency.HystrixRequestContext}
+     * If the task handler is not a {@link HystrixTaskHandler} then it returns null, which bypasses the request
+     * caching mechanism in hystrix
+     *
+     * @return String cache key
+     */
+    @Override
+    protected String getCacheKey(){
+        if (this.taskHandler instanceof HystrixTaskHandler){
+            HystrixTaskHandler hystrixTaskHandler = (HystrixTaskHandler) this.taskHandler;
+            return hystrixTaskHandler.getCacheKey();
+        }
+        return null;
+    }
+
+    /**
      * First It checks the call invocation type has been overridden for the command,
      * if not, it defaults to task handler call invocation type.
      *


### PR DESCRIPTION
handlers extending HystrixTaskHandler to implement request caching. This
would also necessiate that HystrixRequestContext be initialized and
shutdown for each request that triggers the task handler. I've
demonstrated the usage of the above by making changes to
HttpProxyExecutor and RoutingHttpChannelHandler.
