### PR TITLE
Fixing hystrix snapshot metrics to report latencies based on average instead of sum

### DIFF
--- a/channel-handler-thrift/src/main/java/com/flipkart/phantom/runtime/impl/server/netty/handler/thrift/ThriftChannelHandler.java
+++ b/channel-handler-thrift/src/main/java/com/flipkart/phantom/runtime/impl/server/netty/handler/thrift/ThriftChannelHandler.java
@@ -161,6 +161,7 @@ public class ThriftChannelHandler extends SimpleChannelUpstreamHandler implement
      * @see org.jboss.netty.channel.SimpleChannelUpstreamHandler#handleUpstream(org.jboss.netty.channel.ChannelHandlerContext, org.jboss.netty.channel.ChannelEvent)
      */
     public void handleUpstream(ChannelHandlerContext ctx, ChannelEvent event) throws Exception {
+        LOGGER.info("CheckPoint 0");
         long receiveTime = System.currentTimeMillis();
         if (MessageEvent.class.isAssignableFrom(event.getClass())) {
 
@@ -177,20 +178,25 @@ public class ThriftChannelHandler extends SimpleChannelUpstreamHandler implement
             input.resetReaderIndex();
 
             ThriftRequestWrapper thriftRequestWrapper = new ThriftRequestWrapper();
+            LOGGER.info("CheckPoint 1");
             thriftRequestWrapper.setClientSocket(clientTransport);
             thriftRequestWrapper.setMethodName(message.name);
             // set the service name for the request
+            LOGGER.info("CheckPoint 2");
             thriftRequestWrapper.setServiceName(Optional.of(this.serviceName));
 
             // Create and process a Server request interceptor. This will initialize the server tracing
+            LOGGER.info("CheckPoint 3");
             ServerRequestInterceptor<ThriftRequestWrapper, TTransport> serverRequestInterceptor = this.initializeServerTracing(thriftRequestWrapper);
 
             //Execute
+            LOGGER.info("CheckPoint 4");
             Executor<ThriftRequestWrapper,TTransport> executor = this.repository.getExecutor(message.name, this.thriftProxy, thriftRequestWrapper);
             // set the service name for the request
             thriftRequestWrapper.setServiceName(executor.getServiceName());
             
-            Optional<RuntimeException> transportError = Optional.absent();            
+            LOGGER.info("CheckPoint 5");
+            Optional<RuntimeException> transportError = Optional.absent();
             try {
                 executor.execute();
             } catch (Exception e) {
@@ -199,25 +205,33 @@ public class ThriftChannelHandler extends SimpleChannelUpstreamHandler implement
                 throw runtimeException;
             } finally {
             	// finally inform the server request tracer
-            	serverRequestInterceptor.process(clientTransport, transportError);            	
+                LOGGER.info("CheckPoint 6");
+            	serverRequestInterceptor.process(clientTransport, transportError);
+                LOGGER.info("CheckPoint 7");
                 if (eventProducer != null) {
                     // Publishes event both in case of success and failure.
                     ServiceProxyEvent.Builder eventBuilder;
+                    LOGGER.info("CheckPoint 8");
                     if (executor == null) {
                         eventBuilder = new ServiceProxyEvent.Builder(thriftProxy + ":" + message.name, THRIFT_HANDLER).withEventSource(getClass().getName());
                     } else {
                         eventBuilder = executor.getEventBuilder().withCommandData(executor).withEventSource(executor.getClass().getName());
                     }
+                    LOGGER.info("CheckPoint 9");
                     eventBuilder.withRequestReceiveTime(receiveTime);
+                    LOGGER.info("CheckPoint 10");
                     eventProducer.publishEvent(eventBuilder.build());
                 } else {
                     LOGGER.debug("eventProducer not set, not publishing event");
                 }
             }
             // write the result to the output channel buffer
+            LOGGER.info("CheckPoint 11");
             Channels.write(ctx, event.getFuture(), ((ThriftNettyChannelBuffer) clientTransport).getOutputBuffer());
         }
+        LOGGER.info("CheckPoint 12");
         super.handleUpstream(ctx, event);
+        LOGGER.info("CheckPoint 13");
     }
 
     /**

--- a/channel-handler-thrift/src/main/java/com/flipkart/phantom/runtime/impl/server/netty/handler/thrift/ThriftChannelHandler.java
+++ b/channel-handler-thrift/src/main/java/com/flipkart/phantom/runtime/impl/server/netty/handler/thrift/ThriftChannelHandler.java
@@ -161,7 +161,6 @@ public class ThriftChannelHandler extends SimpleChannelUpstreamHandler implement
      * @see org.jboss.netty.channel.SimpleChannelUpstreamHandler#handleUpstream(org.jboss.netty.channel.ChannelHandlerContext, org.jboss.netty.channel.ChannelEvent)
      */
     public void handleUpstream(ChannelHandlerContext ctx, ChannelEvent event) throws Exception {
-        LOGGER.info("CheckPoint 0");
         long receiveTime = System.currentTimeMillis();
         if (MessageEvent.class.isAssignableFrom(event.getClass())) {
 
@@ -178,25 +177,20 @@ public class ThriftChannelHandler extends SimpleChannelUpstreamHandler implement
             input.resetReaderIndex();
 
             ThriftRequestWrapper thriftRequestWrapper = new ThriftRequestWrapper();
-            LOGGER.info("CheckPoint 1");
             thriftRequestWrapper.setClientSocket(clientTransport);
             thriftRequestWrapper.setMethodName(message.name);
             // set the service name for the request
-            LOGGER.info("CheckPoint 2");
             thriftRequestWrapper.setServiceName(Optional.of(this.serviceName));
 
             // Create and process a Server request interceptor. This will initialize the server tracing
-            LOGGER.info("CheckPoint 3");
             ServerRequestInterceptor<ThriftRequestWrapper, TTransport> serverRequestInterceptor = this.initializeServerTracing(thriftRequestWrapper);
 
             //Execute
-            LOGGER.info("CheckPoint 4");
             Executor<ThriftRequestWrapper,TTransport> executor = this.repository.getExecutor(message.name, this.thriftProxy, thriftRequestWrapper);
             // set the service name for the request
             thriftRequestWrapper.setServiceName(executor.getServiceName());
             
-            LOGGER.info("CheckPoint 5");
-            Optional<RuntimeException> transportError = Optional.absent();
+            Optional<RuntimeException> transportError = Optional.absent();            
             try {
                 executor.execute();
             } catch (Exception e) {
@@ -205,33 +199,25 @@ public class ThriftChannelHandler extends SimpleChannelUpstreamHandler implement
                 throw runtimeException;
             } finally {
             	// finally inform the server request tracer
-                LOGGER.info("CheckPoint 6");
-            	serverRequestInterceptor.process(clientTransport, transportError);
-                LOGGER.info("CheckPoint 7");
+            	serverRequestInterceptor.process(clientTransport, transportError);            	
                 if (eventProducer != null) {
                     // Publishes event both in case of success and failure.
                     ServiceProxyEvent.Builder eventBuilder;
-                    LOGGER.info("CheckPoint 8");
                     if (executor == null) {
                         eventBuilder = new ServiceProxyEvent.Builder(thriftProxy + ":" + message.name, THRIFT_HANDLER).withEventSource(getClass().getName());
                     } else {
                         eventBuilder = executor.getEventBuilder().withCommandData(executor).withEventSource(executor.getClass().getName());
                     }
-                    LOGGER.info("CheckPoint 9");
                     eventBuilder.withRequestReceiveTime(receiveTime);
-                    LOGGER.info("CheckPoint 10");
                     eventProducer.publishEvent(eventBuilder.build());
                 } else {
                     LOGGER.debug("eventProducer not set, not publishing event");
                 }
             }
             // write the result to the output channel buffer
-            LOGGER.info("CheckPoint 11");
             Channels.write(ctx, event.getFuture(), ((ThriftNettyChannelBuffer) clientTransport).getOutputBuffer());
         }
-        LOGGER.info("CheckPoint 12");
         super.handleUpstream(ctx, event);
-        LOGGER.info("CheckPoint 13");
     }
 
     /**

--- a/runtime/src/main/java/com/flipkart/phantom/runtime/impl/hystrix/impl/MetricsSnapshotReporterWithAggregation.java
+++ b/runtime/src/main/java/com/flipkart/phantom/runtime/impl/hystrix/impl/MetricsSnapshotReporterWithAggregation.java
@@ -19,8 +19,6 @@ import com.flipkart.phantom.runtime.impl.hystrix.MetricsSnapshotReporter;
 import com.netflix.hystrix.HystrixCommandMetrics;
 import com.netflix.hystrix.HystrixThreadPoolMetrics;
 import com.netflix.hystrix.util.HystrixRollingNumberEvent;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -77,17 +75,18 @@ public class MetricsSnapshotReporterWithAggregation implements Runnable, Metrics
             currStats.put("rollingCountSuccess", commandMetrics.getRollingCount(HystrixRollingNumberEvent.SUCCESS) + zeroIfNull(currStats.get("rollingCountSuccess")));
             currStats.put("rollingCountThreadPoolRejected", commandMetrics.getRollingCount(HystrixRollingNumberEvent.THREAD_POOL_REJECTED) + zeroIfNull(currStats.get("rollingCountThreadPoolRejected")));
             currStats.put("rollingCountTimeout", commandMetrics.getRollingCount(HystrixRollingNumberEvent.TIMEOUT) + zeroIfNull(currStats.get("rollingCountTimeout")));
-            currStats.put("latencyTotal_mean", (long) commandMetrics.getTotalTimeMean() + zeroIfNull(currStats.get("latencyTotal_mean")));
 
-            currStats.put("0", (long) commandMetrics.getTotalTimePercentile(0) + zeroIfNull(currStats.get("0")));
-            currStats.put("25", (long) commandMetrics.getTotalTimePercentile(25) + zeroIfNull(currStats.get("25")));
-            currStats.put("50", (long) commandMetrics.getTotalTimePercentile(50) + zeroIfNull(currStats.get("50")));
-            currStats.put("75", (long) commandMetrics.getTotalTimePercentile(75) + zeroIfNull(currStats.get("75")));
-            currStats.put("90", (long) commandMetrics.getTotalTimePercentile(90) + zeroIfNull(currStats.get("90")));
-            currStats.put("95", (long) commandMetrics.getTotalTimePercentile(95) + zeroIfNull(currStats.get("95")));
-            currStats.put("99", (long) commandMetrics.getTotalTimePercentile(99) + zeroIfNull(currStats.get("99")));
-            currStats.put("99.5", (long) commandMetrics.getTotalTimePercentile(99.5) + zeroIfNull(currStats.get("99.5")));
-            currStats.put("100", (long) commandMetrics.getTotalTimePercentile(100) + zeroIfNull(currStats.get("100")));
+            /* Divide below with frequency as they are latencies */
+            currStats.put("latencyTotal_mean", (long) commandMetrics.getTotalTimeMean()/frequency + zeroIfNull(currStats.get("latencyTotal_mean")));
+            currStats.put("0", (long) commandMetrics.getTotalTimePercentile(0)/frequency + zeroIfNull(currStats.get("0")));
+            currStats.put("25", (long) commandMetrics.getTotalTimePercentile(25)/frequency + zeroIfNull(currStats.get("25")));
+            currStats.put("50", (long) commandMetrics.getTotalTimePercentile(50)/frequency + zeroIfNull(currStats.get("50")));
+            currStats.put("75", (long) commandMetrics.getTotalTimePercentile(75)/frequency + zeroIfNull(currStats.get("75")));
+            currStats.put("90", (long) commandMetrics.getTotalTimePercentile(90)/frequency + zeroIfNull(currStats.get("90")));
+            currStats.put("95", (long) commandMetrics.getTotalTimePercentile(95)/frequency + zeroIfNull(currStats.get("95")));
+            currStats.put("99", (long) commandMetrics.getTotalTimePercentile(99)/frequency + zeroIfNull(currStats.get("99")));
+            currStats.put("99.5", (long) commandMetrics.getTotalTimePercentile(99.5)/frequency + zeroIfNull(currStats.get("99.5")));
+            currStats.put("100", (long) commandMetrics.getTotalTimePercentile(100)/frequency + zeroIfNull(currStats.get("100")));
 
             currentMetrics.get("HystrixCommand").put(commandName, currStats);
         }


### PR DESCRIPTION
Divide by frequency while using Hystrix current metrics latencies and add to existing value.