### PR TITLE
Support generic return type in TaskHandler's execute()

### DIFF
--- a/sample-task-proxy/src/main/java/com/flipkart/phantom/sample/handler/ArithmeticTaskHandler.java
+++ b/sample-task-proxy/src/main/java/com/flipkart/phantom/sample/handler/ArithmeticTaskHandler.java
@@ -40,19 +40,19 @@ public class ArithmeticTaskHandler extends HystrixTaskHandler {
      * @see com.flipkart.phantom.task.impl.TaskHandler#execute(com.flipkart.phantom.task.spi.TaskContext, String, java.util.Map, Object)
      */
     @Override
-    public <S> TaskResult<byte[]> execute(TaskContext taskContext, String command, Map<String, String> params, S data) throws RuntimeException {
+    public <T, S> TaskResult<T> execute(TaskContext taskContext, String command, Map<String, String> params, S data) throws RuntimeException {
 
         float num1 = Float.parseFloat(params.get("num1"));
         float num2 = Float.parseFloat(params.get("num2"));
 
         if (CMD_ADD.equals(command)) {
-            return new TaskResult<byte[]>(true, Float.toString(num1+num2));
+            return new TaskResult(true, null, num1+num2);
         } else if (CMD_SUB.equals(command)) {
-            return new TaskResult<byte[]>(true, Float.toString(num1+num2));
+            return new TaskResult(true, null, num1-num2);
         } else if (CMD_MUL.equals(command)) {
-            return new TaskResult<byte[]>(true, Float.toString(num1+num2));
+            return new TaskResult(true, null, num1*num2);
         } else if (CMD_DIV.equals(command)) {
-            return new TaskResult<byte[]>(true, Float.toString(num1+num2));
+            return new TaskResult(true, null, num1/num2);
         } else {
             return null;
         }
@@ -91,7 +91,7 @@ public class ArithmeticTaskHandler extends HystrixTaskHandler {
      * @see com.flipkart.phantom.task.impl.HystrixTaskHandler#getFallBack(com.flipkart.phantom.task.spi.TaskContext, String, java.util.Map, Object)
      */
     @Override
-    public <S> TaskResult<byte[]> getFallBack(TaskContext taskContext, String command, Map<String, String> params, S data) {
+    public <T, S> TaskResult<T> getFallBack(TaskContext taskContext, String command, Map<String, String> params, S data) {
         return null;
     }
 

--- a/task/src/main/java/com/flipkart/phantom/task/impl/HystrixTaskHandler.java
+++ b/task/src/main/java/com/flipkart/phantom/task/impl/HystrixTaskHandler.java
@@ -72,7 +72,7 @@ public abstract class HystrixTaskHandler extends TaskHandler {
      * @param data extra data if any
      * @return response
      */
-    public abstract <S> TaskResult<byte[]> getFallBack(TaskContext taskContext, String command, Map<String,String> params, S data);
+    public abstract <T, S> TaskResult<T> getFallBack(TaskContext taskContext, String command, Map<String,String> params, S data);
 
     /**
      * Returns null. Sub-Classes should override it, if they need fallback functionality.

--- a/task/src/main/java/com/flipkart/phantom/task/impl/TaskHandler.java
+++ b/task/src/main/java/com/flipkart/phantom/task/impl/TaskHandler.java
@@ -135,7 +135,7 @@ public abstract class TaskHandler extends AbstractHandler implements DisposableB
      * @return response the TaskResult from thrift execution
      * @throws RuntimeException runTimeException
      */
-    public abstract <S> TaskResult<byte[]> execute(TaskContext taskContext, String command, Map<String,String> params, S data) throws RuntimeException;
+    public abstract <T, S> TaskResult<T> execute(TaskContext taskContext, String command, Map<String,String> params, S data) throws RuntimeException;
 
     /**
      * This is a over-loaded method that needs to be implemented by sub-classes. The default implementation

--- a/task/src/main/java/com/flipkart/phantom/task/spi/TaskResult.java
+++ b/task/src/main/java/com/flipkart/phantom/task/spi/TaskResult.java
@@ -155,7 +155,7 @@ public class TaskResult<T> {
     public String getMessage() {
         return message;
     }
-    public Object getData() {
+    public T getData() {
         return data;
     }
     public List<T> getDataArray() {


### PR DESCRIPTION
Support generic return type in TaskHandler's execute() and HystrixTaskHandler's getFallBack()

TaskHandler's execute (without decoder) method's return type is not a generic type (its byte[]). TaskHandlers to data stores might get deserialized Objects directly from the datastore client (say couchbase client using WhalinTranscoder decompresses and deserializes the fetched data as Java Object).  Because of TaskResult<byte[]> restriction, such task handlers are forced to not use data store client's in-built deserialization mechanisms or in the worst case, serialize an already deserialized Object back to byte[] which adds one extra serialization-deserialization loop in each request.

Even the sample ArithmeticTaskHandler is converting the float to String and sending the result in message String. Ideally it shouldn't convert float to string or byte[]. It should just send float as it is as TaskResult's data.