### PR TITLE
Avoid serialization-deserialization in request params

### DIFF
--- a/runtime-oio-uds/src/main/java/com/flipkart/phantom/runtime/impl/server/oio/UDSOIOServer.java
+++ b/runtime-oio-uds/src/main/java/com/flipkart/phantom/runtime/impl/server/oio/UDSOIOServer.java
@@ -283,7 +283,7 @@ public class UDSOIOServer extends AbstractNetworkServer {
                 CommandInterpreter commandInterpreter = new CommandInterpreter();
                 readCommand = commandInterpreter.readCommand(client.getInputStream());
                 LOGGER.debug("Read Command : " + readCommand);
-                String pool = readCommand.getCommandParams().get("pool").toString();
+                String pool = (String) readCommand.getCommandParams().get("pool");
 
                 // Prepare the request Wrapper
                 TaskRequestWrapper<byte[]> taskRequestWrapper = new TaskRequestWrapper<byte[]>();
@@ -332,9 +332,9 @@ public class UDSOIOServer extends AbstractNetworkServer {
                     } else {
                         eventBuilder = executor.getEventBuilder().withCommandData(executor).withEventSource(executor.getClass().getName());
                     }
-                    eventBuilder.withRequestId(params.get("requestID").toString()).withRequestReceiveTime(receiveTime);
+                    eventBuilder.withRequestId((String) params.get("requestID")).withRequestReceiveTime(receiveTime);
                     if(params.containsKey("requestSentTime")) {
-                        eventBuilder.withRequestSentTime(Long.valueOf(params.get("requestSentTime").toString()));
+                        eventBuilder.withRequestSentTime(Long.valueOf((String) params.get("requestSentTime")));
                     }
                     eventProducer.publishEvent(eventBuilder.build());
                 } else {

--- a/runtime-oio-uds/src/main/java/com/flipkart/phantom/runtime/impl/server/oio/UDSOIOServer.java
+++ b/runtime-oio-uds/src/main/java/com/flipkart/phantom/runtime/impl/server/oio/UDSOIOServer.java
@@ -283,7 +283,7 @@ public class UDSOIOServer extends AbstractNetworkServer {
                 CommandInterpreter commandInterpreter = new CommandInterpreter();
                 readCommand = commandInterpreter.readCommand(client.getInputStream());
                 LOGGER.debug("Read Command : " + readCommand);
-                String pool = readCommand.getCommandParams().get("pool");
+                String pool = readCommand.getCommandParams().get("pool").toString();
 
                 // Prepare the request Wrapper
                 TaskRequestWrapper<byte[]> taskRequestWrapper = new TaskRequestWrapper<byte[]>();
@@ -325,16 +325,16 @@ public class UDSOIOServer extends AbstractNetworkServer {
             	}
                 if (eventProducer != null) {
                     // Publishes event both in case of success and failure.
-                    final Map<String, String> params = readCommand.getCommandParams();
+                    final Map<String, Object> params = readCommand.getCommandParams();
                     ServiceProxyEvent.Builder eventBuilder;
                     if(executor==null) {
                         eventBuilder = new ServiceProxyEvent.Builder(readCommand.getCommand(), COMMAND_HANDLER).withEventSource(getClass().getName());
                     } else {
                         eventBuilder = executor.getEventBuilder().withCommandData(executor).withEventSource(executor.getClass().getName());
                     }
-                    eventBuilder.withRequestId(params.get("requestID")).withRequestReceiveTime(receiveTime);
+                    eventBuilder.withRequestId(params.get("requestID").toString()).withRequestReceiveTime(receiveTime);
                     if(params.containsKey("requestSentTime")) {
-                        eventBuilder.withRequestSentTime(Long.valueOf(params.get("requestSentTime")));
+                        eventBuilder.withRequestSentTime(Long.valueOf(params.get("requestSentTime").toString()));
                     }
                     eventProducer.publishEvent(eventBuilder.build());
                 } else {
@@ -353,7 +353,7 @@ public class UDSOIOServer extends AbstractNetworkServer {
 
     /**
      * Initializes server tracing for the specified request
-     * @param executorHttpRequest the Http request 
+     * @param executorRequest the Http request
      * @return the initialized ServerRequestInterceptor
      */
     private ServerRequestInterceptor<TaskRequestWrapper, TaskResult> initializeServerTracing(TaskRequestWrapper executorRequest) {

--- a/runtime/src/main/java/com/flipkart/phantom/runtime/impl/server/netty/handler/command/AsyncCommandProcessingChannelHandler.java
+++ b/runtime/src/main/java/com/flipkart/phantom/runtime/impl/server/netty/handler/command/AsyncCommandProcessingChannelHandler.java
@@ -148,7 +148,7 @@ public class AsyncCommandProcessingChannelHandler extends SimpleChannelUpstreamH
             CommandInterpreter commandInterpreter = new CommandInterpreter();
             CommandInterpreter.ProxyCommand readCommand = commandInterpreter.readCommand((MessageEvent) event);
             LOGGER.debug("Read Command : " + readCommand);
-            String pool = readCommand.getCommandParams().get("pool").toString();
+            String pool = (String) readCommand.getCommandParams().get("pool");
             String commandName = readCommand.getCommand();
             String poolName;
             if (pool != null) {
@@ -184,7 +184,7 @@ public class AsyncCommandProcessingChannelHandler extends SimpleChannelUpstreamH
             	serverRequestInterceptor.process(new TaskResult(true, TaskHandlerExecutor.ASYNC_QUEUED), transportError);
                 if (eventProducer != null) {
                     // Publishes event both in case of success and failure.
-                    final String requestID = readCommand.getCommandParams().get("requestID").toString();
+                    final String requestID = (String) readCommand.getCommandParams().get("requestID");
                     ServiceProxyEvent.Builder eventBuilder;
                     if (executor == null) {
                         eventBuilder = new ServiceProxyEvent.Builder(readCommand.getCommand(), ASYNC_COMMAND_HANDLER).withEventSource(getClass().getName());

--- a/runtime/src/main/java/com/flipkart/phantom/runtime/impl/server/netty/handler/command/AsyncCommandProcessingChannelHandler.java
+++ b/runtime/src/main/java/com/flipkart/phantom/runtime/impl/server/netty/handler/command/AsyncCommandProcessingChannelHandler.java
@@ -148,7 +148,7 @@ public class AsyncCommandProcessingChannelHandler extends SimpleChannelUpstreamH
             CommandInterpreter commandInterpreter = new CommandInterpreter();
             CommandInterpreter.ProxyCommand readCommand = commandInterpreter.readCommand((MessageEvent) event);
             LOGGER.debug("Read Command : " + readCommand);
-            String pool = readCommand.getCommandParams().get("pool");
+            String pool = readCommand.getCommandParams().get("pool").toString();
             String commandName = readCommand.getCommand();
             String poolName;
             if (pool != null) {
@@ -184,7 +184,7 @@ public class AsyncCommandProcessingChannelHandler extends SimpleChannelUpstreamH
             	serverRequestInterceptor.process(new TaskResult(true, TaskHandlerExecutor.ASYNC_QUEUED), transportError);
                 if (eventProducer != null) {
                     // Publishes event both in case of success and failure.
-                    final String requestID = readCommand.getCommandParams().get("requestID");
+                    final String requestID = readCommand.getCommandParams().get("requestID").toString();
                     ServiceProxyEvent.Builder eventBuilder;
                     if (executor == null) {
                         eventBuilder = new ServiceProxyEvent.Builder(readCommand.getCommand(), ASYNC_COMMAND_HANDLER).withEventSource(getClass().getName());
@@ -212,7 +212,7 @@ public class AsyncCommandProcessingChannelHandler extends SimpleChannelUpstreamH
 
     /**
      * Initializes server tracing for the specified request
-     * @param executorHttpRequest the Http request 
+     * @param executorRequest the Http request
      * @return the initialized ServerRequestInterceptor
      */
     private ServerRequestInterceptor<TaskRequestWrapper, TaskResult> initializeServerTracing(TaskRequestWrapper executorRequest) {

--- a/runtime/src/main/java/com/flipkart/phantom/runtime/impl/server/netty/handler/command/CommandInterpreter.java
+++ b/runtime/src/main/java/com/flipkart/phantom/runtime/impl/server/netty/handler/command/CommandInterpreter.java
@@ -264,7 +264,7 @@ public class CommandInterpreter {
 		int fragmentIndex = this.getNextCommandFragmentPosition(readBytes, fragmentStart, commandEndIndex, delimiter);
 		readCommand = new ProxyCommand(new String(readBytes, fragmentStart, fragmentIndex-fragmentStart));
 
-		Map<String,String> commandParams = new HashMap<String, String>();
+		Map<String, Object> commandParams = new HashMap<>();
 		// gather params
 		while(fragmentIndex < commandEndIndex) {
 			// skip initial delims
@@ -355,7 +355,7 @@ public class CommandInterpreter {
 		private String readFailureDescription;
 
 		/** The command parameters*/
-		private Map<String, String> commandParams = new HashMap<String, String>();
+		private Map<String, Object> commandParams = new HashMap<>();
 
 		/** The command data*/
 		private byte[] commandData;
@@ -402,10 +402,10 @@ public class CommandInterpreter {
 		public String getReadFailureDescription() {
 			return readFailureDescription;
 		}
-		public Map<String, String> getCommandParams() {
+		public Map<String, Object> getCommandParams() {
 			return commandParams;
 		}
-		public void setCommandParams(Map<String, String> commandParams) {
+		public void setCommandParams(Map<String, Object> commandParams) {
 			this.commandParams = commandParams;
 		}
 		public byte[] getCommandData() {

--- a/runtime/src/main/java/com/flipkart/phantom/runtime/impl/server/netty/handler/command/CommandProcessingChannelHandler.java
+++ b/runtime/src/main/java/com/flipkart/phantom/runtime/impl/server/netty/handler/command/CommandProcessingChannelHandler.java
@@ -151,7 +151,7 @@ public class CommandProcessingChannelHandler extends SimpleChannelUpstreamHandle
             CommandInterpreter commandInterpreter = new CommandInterpreter();
             CommandInterpreter.ProxyCommand readCommand = commandInterpreter.readCommand((MessageEvent) event);
             LOGGER.debug("Read Command : " + readCommand);
-            String pool = readCommand.getCommandParams().get("pool");
+            String pool = readCommand.getCommandParams().get("pool").toString();
             TaskHandlerExecutor executor;
 
             // Prepare the request Wrapper
@@ -195,7 +195,7 @@ public class CommandProcessingChannelHandler extends SimpleChannelUpstreamHandle
             	serverRequestInterceptor.process(result, transportError);
                 if (eventProducer != null) {
                     // Publishes event both in case of success and failure.
-                    final String requestID = readCommand.getCommandParams().get("requestID");
+                    final String requestID = readCommand.getCommandParams().get("requestID").toString();
                     ServiceProxyEvent.Builder eventBuilder;
                     if (executor == null) {
                         eventBuilder = new ServiceProxyEvent.Builder(readCommand.getCommand(), COMMAND_HANDLER).withEventSource(getClass().getName());

--- a/runtime/src/main/java/com/flipkart/phantom/runtime/impl/server/netty/handler/command/CommandProcessingChannelHandler.java
+++ b/runtime/src/main/java/com/flipkart/phantom/runtime/impl/server/netty/handler/command/CommandProcessingChannelHandler.java
@@ -151,7 +151,7 @@ public class CommandProcessingChannelHandler extends SimpleChannelUpstreamHandle
             CommandInterpreter commandInterpreter = new CommandInterpreter();
             CommandInterpreter.ProxyCommand readCommand = commandInterpreter.readCommand((MessageEvent) event);
             LOGGER.debug("Read Command : " + readCommand);
-            String pool = readCommand.getCommandParams().get("pool").toString();
+            String pool = (String) readCommand.getCommandParams().get("pool");
             TaskHandlerExecutor executor;
 
             // Prepare the request Wrapper
@@ -195,7 +195,7 @@ public class CommandProcessingChannelHandler extends SimpleChannelUpstreamHandle
             	serverRequestInterceptor.process(result, transportError);
                 if (eventProducer != null) {
                     // Publishes event both in case of success and failure.
-                    final String requestID = readCommand.getCommandParams().get("requestID").toString();
+                    final String requestID = (String) readCommand.getCommandParams().get("requestID");
                     ServiceProxyEvent.Builder eventBuilder;
                     if (executor == null) {
                         eventBuilder = new ServiceProxyEvent.Builder(readCommand.getCommand(), COMMAND_HANDLER).withEventSource(getClass().getName());

--- a/sample-task-proxy/src/main/java/com/flipkart/phantom/sample/handler/ArithmeticTaskHandler.java
+++ b/sample-task-proxy/src/main/java/com/flipkart/phantom/sample/handler/ArithmeticTaskHandler.java
@@ -40,10 +40,10 @@ public class ArithmeticTaskHandler extends HystrixTaskHandler {
      * @see com.flipkart.phantom.task.impl.TaskHandler#execute(com.flipkart.phantom.task.spi.TaskContext, String, java.util.Map, Object)
      */
     @Override
-    public <T, S> TaskResult<T> execute(TaskContext taskContext, String command, Map<String, String> params, S data) throws RuntimeException {
+    public <T, S> TaskResult<T> execute(TaskContext taskContext, String command, Map<String, Object> params, S data) throws RuntimeException {
 
-        float num1 = Float.parseFloat(params.get("num1"));
-        float num2 = Float.parseFloat(params.get("num2"));
+        float num1 = (float) params.get("num1");
+        float num2 = (float) params.get("num2");
 
         if (CMD_ADD.equals(command)) {
             return new TaskResult(true, null, num1+num2);
@@ -91,7 +91,7 @@ public class ArithmeticTaskHandler extends HystrixTaskHandler {
      * @see com.flipkart.phantom.task.impl.HystrixTaskHandler#getFallBack(com.flipkart.phantom.task.spi.TaskContext, String, java.util.Map, Object)
      */
     @Override
-    public <T, S> TaskResult<T> getFallBack(TaskContext taskContext, String command, Map<String, String> params, S data) {
+    public <T, S> TaskResult<T> getFallBack(TaskContext taskContext, String command, Map<String, Object> params, S data) {
         return null;
     }
 

--- a/task/src/main/java/com/flipkart/phantom/task/impl/HystrixTaskHandler.java
+++ b/task/src/main/java/com/flipkart/phantom/task/impl/HystrixTaskHandler.java
@@ -72,7 +72,7 @@ public abstract class HystrixTaskHandler extends TaskHandler {
      * @param data extra data if any
      * @return response
      */
-    public abstract <T, S> TaskResult<T> getFallBack(TaskContext taskContext, String command, Map<String,String> params, S data);
+    public abstract <T, S> TaskResult<T> getFallBack(TaskContext taskContext, String command, Map<String, Object> params, S data);
 
     /**
      * Returns null. Sub-Classes should override it, if they need fallback functionality.

--- a/task/src/main/java/com/flipkart/phantom/task/impl/TaskContextImpl.java
+++ b/task/src/main/java/com/flipkart/phantom/task/impl/TaskContextImpl.java
@@ -74,7 +74,7 @@ public class TaskContextImpl implements TaskContext {
      * @return the config as string, empty string if not found/error
      */
 	public String getConfig(String group, String key, int count) {
-        Map<String, String> params = new HashMap<String, String>();
+        Map<String, Object> params = new HashMap<>();
         params.put("group", group);
         params.put("key", key);
         params.put("count", Integer.toString(count));
@@ -89,7 +89,7 @@ public class TaskContextImpl implements TaskContext {
      * Executes a command
      */
     @Override
-    public <S> TaskResult executeCommand(String commandName, S data, Map<String, String> params) throws UnsupportedOperationException {
+    public <S> TaskResult executeCommand(String commandName, S data, Map<String, Object> params) throws UnsupportedOperationException {
         return this.executorRepository.executeCommand(commandName, this.createRequestFromParams(commandName, data, params));
     }
 
@@ -99,22 +99,22 @@ public class TaskContextImpl implements TaskContext {
     }
 
     @Override
-    public <T, S> TaskResult<T> executeCommand(String commandName, S data, Map<String, String> params, Decoder<T> decoder) throws UnsupportedOperationException {
+    public <T, S> TaskResult<T> executeCommand(String commandName, S data, Map<String, Object> params, Decoder<T> decoder) throws UnsupportedOperationException {
         return this.executorRepository.executeCommand(commandName, this.createRequestFromParams(commandName, data, params),decoder);
     }
 
     @Override
-    public <S> Future<TaskResult> executeAsyncCommand(String commandName, S data, Map<String, String> params, Decoder decoder) throws UnsupportedOperationException {
+    public <S> Future<TaskResult> executeAsyncCommand(String commandName, S data, Map<String, Object> params, Decoder decoder) throws UnsupportedOperationException {
         return this.executorRepository.executeAsyncCommand(commandName, this.createRequestFromParams(commandName, data, params),decoder);
     }
 
     @Override
-    public <S> Future<TaskResult> executeAsyncCommand(String commandName, S data, Map<String, String> params) throws UnsupportedOperationException {
+    public <S> Future<TaskResult> executeAsyncCommand(String commandName, S data, Map<String, Object> params) throws UnsupportedOperationException {
         return this.executorRepository.executeAsyncCommand(commandName, this.createRequestFromParams(commandName, data, params));
     }
     
     /** Creates a TaskRequestWrapper from passed in params and sets the current server span on it*/
-    private <S> TaskRequestWrapper createRequestFromParams(String commandName, S data, Map<String, String> params) {
+    private <S> TaskRequestWrapper createRequestFromParams(String commandName, S data, Map<String, Object> params) {
         TaskRequestWrapper taskRequestWrapper = new TaskRequestWrapper();
         taskRequestWrapper.setCommandName(commandName);
         taskRequestWrapper.setData(data);

--- a/task/src/main/java/com/flipkart/phantom/task/impl/TaskHandler.java
+++ b/task/src/main/java/com/flipkart/phantom/task/impl/TaskHandler.java
@@ -118,7 +118,7 @@ public abstract class TaskHandler extends AbstractHandler implements DisposableB
                     LOGGER.error("Fatal error. commandName not specified in initializationCommands for TaskHandler: " + this.getName());
                     throw new UnsupportedOperationException("Fatal error. commandName not specified in initializationCommands of TaskHandler: "+this.getName());
                 }
-                TaskResult result = this.execute(taskContext, commandName, new HashMap<String, String>(initParam), null);
+                TaskResult result = this.execute(taskContext, commandName, new HashMap<>(initParam), null);
                 if (result != null && !result.isSuccess()) {
                     throw new PlatformException("Initialization command: "+commandName+" failed for TaskHandler: "+this.getName()+" The params were: "+initParam);
                 }
@@ -135,7 +135,7 @@ public abstract class TaskHandler extends AbstractHandler implements DisposableB
      * @return response the TaskResult from thrift execution
      * @throws RuntimeException runTimeException
      */
-    public abstract <T, S> TaskResult<T> execute(TaskContext taskContext, String command, Map<String,String> params, S data) throws RuntimeException;
+    public abstract <T, S> TaskResult<T> execute(TaskContext taskContext, String command, Map<String, Object> params, S data) throws RuntimeException;
 
     /**
      * This is a over-loaded method that needs to be implemented by sub-classes. The default implementation

--- a/task/src/main/java/com/flipkart/phantom/task/impl/TaskHandlerExecutor.java
+++ b/task/src/main/java/com/flipkart/phantom/task/impl/TaskHandlerExecutor.java
@@ -74,7 +74,7 @@ public class TaskHandlerExecutor<S> extends HystrixCommand<TaskResult> implement
     protected String command;
 
     /** The parameters which are utilized by the task for execution */
-    protected Map<String,String> params;
+    protected Map<String, Object> params;
 
     /** Data which is utilized by the task for execution */
     protected S data;

--- a/task/src/main/java/com/flipkart/phantom/task/spi/TaskContext.java
+++ b/task/src/main/java/com/flipkart/phantom/task/spi/TaskContext.java
@@ -52,7 +52,7 @@ public interface TaskContext {
      * @return a TaskResult instance with the execution outcome
      * @throws UnsupportedOperationException in case none of the registered TaskHandler instances support the specified command
      */
-	public <S> TaskResult executeCommand(String commandName, S data, Map<String,String> params) throws UnsupportedOperationException;
+	public <S> TaskResult executeCommand(String commandName, S data, Map<String,Object> params) throws UnsupportedOperationException;
 
     /**
      * Executes a task identified by the specified command name. This command executes synchronously.
@@ -77,7 +77,7 @@ public interface TaskContext {
      * @return a TaskResult instance with the execution outcome
      * @throws UnsupportedOperationException in case none of the registered TaskHandler instances support the specified command
      */
-    public <T, S> TaskResult<T> executeCommand(String commandName, S data, Map<String,String> params, Decoder<T> decoder) throws UnsupportedOperationException;
+    public <T, S> TaskResult<T> executeCommand(String commandName, S data, Map<String, Object> params, Decoder<T> decoder) throws UnsupportedOperationException;
 
     /**
      * Executes a task asynchronously identified by the specified command name.
@@ -90,13 +90,13 @@ public interface TaskContext {
      * @return a TaskResult instance with the execution outcome
      * @throws UnsupportedOperationException in case none of the registered TaskHandler instances support the specified command
      */
-    public <S> Future<TaskResult> executeAsyncCommand(String commandName, S data, Map<String,String> params, Decoder decoder) throws UnsupportedOperationException;
+    public <S> Future<TaskResult> executeAsyncCommand(String commandName, S data, Map<String, Object> params, Decoder decoder) throws UnsupportedOperationException;
 
     /**
      * Executes a command asynchronously and returns a {@link Future} to get the {@link TaskResult} from
      * @see TaskContext#executeCommand(String, java.lang.Object, java.util.Map)
      */
-    public <S> Future<TaskResult> executeAsyncCommand(String commandName, S data, Map<String, String> params) throws UnsupportedOperationException;
+    public <S> Future<TaskResult> executeAsyncCommand(String commandName, S data, Map<String, Object> params) throws UnsupportedOperationException;
 
     /** Gets the ObjectMapper instance for result serialization to JSON*/
     public ObjectMapper getObjectMapper();

--- a/task/src/main/java/com/flipkart/phantom/task/spi/TaskRequestWrapper.java
+++ b/task/src/main/java/com/flipkart/phantom/task/spi/TaskRequestWrapper.java
@@ -36,7 +36,7 @@ public class TaskRequestWrapper<S> extends RequestWrapper {
     private S data;
 
     /** Map of parameters */
-    private Map<String,String> params;
+    private Map<String, Object> params;
     
     /** The command name being executed */
     private String commandName;
@@ -80,10 +80,10 @@ public class TaskRequestWrapper<S> extends RequestWrapper {
     public void setData(S data){
         this.data = data;
     }
-    public Map<String, String> getParams(){
+    public Map<String, Object> getParams(){
         return params;
     }
-    public void setParams(Map<String, String> params){
+    public void setParams(Map<String, Object> params){
         this.params = params;
     }
 	public String getCommandName() {


### PR DESCRIPTION
TaskContext and TaskHandler contracts require input parameters to be a Map < String, String >.   So for applications running phantom in embedded mode with a HttpTaskHandler are forced to serialize request params like Headers into a String (which itself is generally a Map < String, String >) and then de-serialize it inside the task handler to read each header key-value and add them to actual http request.
For high qps services with decent number of headers, this is becoming a bottle-neck. Applications should be able to pass URI, Method, Headers etc as they are (strings and maps) instead of converting all of them to string.
Hence changing the request params to Map < String, Object >