### PR TITLE
Making execution error available in fallback execution.

### DIFF
--- a/sample-http-proxy/src/main/resources/external/spring-proxy-handler-config.xml
+++ b/sample-http-proxy/src/main/resources/external/spring-proxy-handler-config.xml
@@ -15,7 +15,7 @@
 
     <!-- http connection pool -->
     <bean id="sampleConnectionPool" class="com.flipkart.phantom.http.impl.HttpConnectionPool">
-        <property name="host" value="www.google.com" />
+        <property name="host" value="www.bing.com" />
         <property name="port" value="80" />
         <property name="connectionTimeout" value="10000" />
         <property name="operationTimeout" value="200000" />

--- a/task-http/src/main/java/com/flipkart/phantom/http/impl/HttpProxy.java
+++ b/task-http/src/main/java/com/flipkart/phantom/http/impl/HttpProxy.java
@@ -16,11 +16,18 @@
 
 package com.flipkart.phantom.http.impl;
 
+import java.util.Map;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.entity.ByteArrayEntity;
+
 import com.flipkart.phantom.task.spi.AbstractHandler;
 import com.flipkart.phantom.task.spi.TaskContext;
-import org.apache.http.HttpResponse;
-import org.apache.http.client.methods.*;
-import org.apache.http.entity.ByteArrayEntity;
 
 /**
  * Abstract class for handling HTTP proxy requests
@@ -129,7 +136,7 @@ public abstract class HttpProxy extends AbstractHandler {
      * @param httpRequestWrapper the http Request Wrapper object
      * @return HttpResponse response after executing the fallback
      */
-    public abstract HttpResponse fallbackRequest(HttpRequestWrapper httpRequestWrapper);
+    public abstract HttpResponse fallbackRequest(HttpRequestWrapper httpRequestWrapper, Map<String,Object> controlParams);
 
     /**
      * Abstract method which gives group key

--- a/task-http/src/main/java/com/flipkart/phantom/http/impl/SimpleHttpProxy.java
+++ b/task-http/src/main/java/com/flipkart/phantom/http/impl/SimpleHttpProxy.java
@@ -16,6 +16,8 @@
 
 package com.flipkart.phantom.http.impl;
 
+import java.util.Map;
+
 import org.apache.http.HttpResponse;
 
 /**
@@ -32,7 +34,7 @@ public class SimpleHttpProxy extends HttpProxy {
      * @see com.flipkart.phantom.http.impl.HttpProxy#fallbackRequest(HttpRequestWrapper)
      */
     @Override
-    public HttpResponse fallbackRequest(HttpRequestWrapper requestWrapper) {
+    public HttpResponse fallbackRequest(HttpRequestWrapper requestWrapper, Map<String,Object> controlParams) {
 		throw new UnsupportedOperationException("No fallback implementation found!");
     }
 

--- a/task-thrift/src/main/java/com/flipkart/phantom/thrift/impl/HystrixThriftProxy.java
+++ b/task-thrift/src/main/java/com/flipkart/phantom/thrift/impl/HystrixThriftProxy.java
@@ -51,7 +51,7 @@ public abstract class HystrixThriftProxy extends ThriftProxy {
 	 * @param clientTransport the Thrift {@link org.apache.thrift.transport.TTransport} of the invoking client
 	 * @throws RuntimeException in case of errors
 	 */
-	public abstract void fallbackThriftRequest(TTransport clientTransport,TaskContext taskContext);
+	public abstract void fallbackThriftRequest(TTransport clientTransport, Map<String,Object> controlParams);
 	
 	/**
 	 * Optional. Gets the GroupName this ThriftProxy should be assigned to. 

--- a/task-thrift/src/main/java/com/flipkart/phantom/thrift/impl/ThriftProxyExecutor.java
+++ b/task-thrift/src/main/java/com/flipkart/phantom/thrift/impl/ThriftProxyExecutor.java
@@ -15,8 +15,10 @@
  */
 package com.flipkart.phantom.thrift.impl;
 
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.thrift.transport.TTransport;
 
@@ -128,9 +130,14 @@ public class ThriftProxyExecutor extends HystrixCommand<TTransport> implements E
      */
     @Override
     protected TTransport getFallback() {
+    	Map<String, Object> controlparams = new HashMap<String,Object>();
+    	// check and populate execution error root cause, if any, for use in fallback
+    	if (this.isFailedExecution()) {
+    		controlparams.put(Executor.EXECUTION_ERROR_CAUSE, this.getFailedExecutionException());
+    	}
         if(this.thriftProxy instanceof HystrixThriftProxy) {
             HystrixThriftProxy hystrixThriftProxy = (HystrixThriftProxy) this.thriftProxy;
-            hystrixThriftProxy.fallbackThriftRequest(this.clientTransport,this.taskContext);
+            hystrixThriftProxy.fallbackThriftRequest(this.clientTransport,controlparams);
             return this.clientTransport;
         }
         return null;

--- a/task-thrift/src/main/java/com/flipkart/phantom/thrift/impl/proxy/DefaultThriftProxy.java
+++ b/task-thrift/src/main/java/com/flipkart/phantom/thrift/impl/proxy/DefaultThriftProxy.java
@@ -16,9 +16,11 @@
 
 package com.flipkart.phantom.thrift.impl.proxy;
 
-import com.flipkart.phantom.task.spi.TaskContext;
-import com.flipkart.phantom.thrift.impl.HystrixThriftProxy;
+import java.util.Map;
+
 import org.apache.thrift.transport.TTransport;
+
+import com.flipkart.phantom.thrift.impl.HystrixThriftProxy;
 
 /**
  * <code>DefaultThriftProxy</code> is an extension of HystrixThriftProxy. It's a default implementation.
@@ -30,7 +32,7 @@ public class DefaultThriftProxy extends HystrixThriftProxy {
 	
 	/** FallBack, to be executed when command fails */
 	@Override
-	public void fallbackThriftRequest(TTransport clientTransport, TaskContext taskContext) {
+	public void fallbackThriftRequest(TTransport clientTransport, Map<String,Object> controlParams) {
 		throw new UnsupportedOperationException("No fallback implementation found!");
 	}
 }

--- a/task/src/main/java/com/flipkart/phantom/task/impl/TaskHandlerExecutor.java
+++ b/task/src/main/java/com/flipkart/phantom/task/impl/TaskHandlerExecutor.java
@@ -263,7 +263,7 @@ public class TaskHandlerExecutor<S> extends HystrixCommand<TaskResult> implement
         				((HystrixTaskHandler)this.taskHandler).releaseResources(result);        			
         			}
         		}
-        	}      	
+        	}     
 	        for (ResponseInterceptor<TaskResult> responseInterceptor : this.responseInterceptors) {
 	        	responseInterceptor.process(result, transportException);
 	        }
@@ -280,6 +280,10 @@ public class TaskHandlerExecutor<S> extends HystrixCommand<TaskResult> implement
     @SuppressWarnings("unchecked")
 	@Override
     protected TaskResult getFallback() {
+    	// check and populate execution error root cause, if any, for use in fallback
+    	if (this.isFailedExecution()) {
+    		this.params.put(Executor.EXECUTION_ERROR_CAUSE, this.getFailedExecutionException());
+    	}
         if(this.taskHandler instanceof HystrixTaskHandler) {
             HystrixTaskHandler hystrixTaskHandler = (HystrixTaskHandler) this.taskHandler;
             if(decoder == null) {

--- a/task/src/main/java/com/flipkart/phantom/task/spi/Executor.java
+++ b/task/src/main/java/com/flipkart/phantom/task/spi/Executor.java
@@ -38,6 +38,9 @@ public interface Executor<T extends RequestWrapper,S> {
 	/** Constant for default service name */
 	public static final String DEFAULT_SERVICE_NAME = "Null Service";
 	
+	/** Constant to identify execution error, passed as request params to fallback method */
+	public static final String EXECUTION_ERROR_CAUSE = "Executor.EXECUTION_ERROR_CAUSE";
+		
 	/**
 	 * Executes a given task and returns the result
 	 * @return task execution result


### PR DESCRIPTION
Made some minor edits to sample URLs as well. Changes are to additionally pass the failure Throwable to params in TaskHandler and new 'controlParams' for Thrift and Http transports. This should not break backward compatibility.